### PR TITLE
Update all links

### DIFF
--- a/dashboards/all_metrics/views/all_chains.py
+++ b/dashboards/all_metrics/views/all_chains.py
@@ -4,19 +4,19 @@ from dashboards.all_metrics.modules.v3 import (
     all_perps,
 )
 
-pages = {
+modules = {
     "LP": all_core.main,
     "Perps": all_perps.main,
 }
 
-page_query = st.query_params["page"] if "page" in st.query_params else None
-state_page = st.sidebar.radio(
+module_query = st.query_params["module"] if "module" in st.query_params else None
+state_module = st.sidebar.radio(
     "All Chains",
-    tuple(pages.keys()),
+    tuple(modules.keys()),
     index=(
-        tuple(pages.keys()).index(page_query)
-        if page_query and page_query in pages.keys()
+        tuple(modules.keys()).index(module_query)
+        if module_query and module_query in modules.keys()
         else 0
     ),
 )
-pages[state_page]()
+modules[state_module]()

--- a/dashboards/all_metrics/views/arbitrum.py
+++ b/dashboards/all_metrics/views/arbitrum.py
@@ -12,7 +12,7 @@ from dashboards.all_metrics.modules.v3 import (
 
 st.session_state.chain = "arbitrum_mainnet"
 
-pages = {
+modules = {
     "LP": chain_core_stats.main,
     "Perps": chain_perp_stats.main,
     "Perps Markets": chain_perp_markets.main,
@@ -23,14 +23,14 @@ pages = {
     "Spot": chain_spot_markets.main,
 }
 
-page_query = st.query_params["page"] if "page" in st.query_params else None
-state_page = st.sidebar.radio(
-    "Arbitrum",
-    tuple(pages.keys()),
+module_query = st.query_params["module"] if "module" in st.query_params else None
+state_module = st.sidebar.radio(
+    "All Chains",
+    tuple(modules.keys()),
     index=(
-        tuple(pages.keys()).index(page_query)
-        if page_query and page_query in pages.keys()
+        tuple(modules.keys()).index(module_query)
+        if module_query and module_query in modules.keys()
         else 0
     ),
 )
-pages[state_page]()
+modules[state_module]()

--- a/dashboards/all_metrics/views/base.py
+++ b/dashboards/all_metrics/views/base.py
@@ -12,7 +12,7 @@ from dashboards.all_metrics.modules.v3 import (
 
 st.session_state.chain = "base_mainnet"
 
-pages = {
+modules = {
     "LP": chain_core_stats.main,
     "Perps": chain_perp_stats.main,
     "Perps Markets": chain_perp_markets.main,
@@ -23,14 +23,14 @@ pages = {
     "Spot": chain_spot_markets.main,
 }
 
-page_query = st.query_params["page"] if "page" in st.query_params else None
-state_page = st.sidebar.radio(
-    "Base",
-    tuple(pages.keys()),
+module_query = st.query_params["module"] if "module" in st.query_params else None
+state_module = st.sidebar.radio(
+    "All Chains",
+    tuple(modules.keys()),
     index=(
-        tuple(pages.keys()).index(page_query)
-        if page_query and page_query in pages.keys()
+        tuple(modules.keys()).index(module_query)
+        if module_query and module_query in modules.keys()
         else 0
     ),
 )
-pages[state_page]()
+modules[state_module]()

--- a/dashboards/all_metrics/views/ethereum.py
+++ b/dashboards/all_metrics/views/ethereum.py
@@ -5,18 +5,18 @@ from dashboards.all_metrics.modules.v3 import (
 
 st.session_state.chain = "eth_mainnet"
 
-pages = {
+modules = {
     "LP": chain_core_stats.main,
 }
 
-page_query = st.query_params["page"] if "page" in st.query_params else None
-state_page = st.sidebar.radio(
-    "Ethereum",
-    tuple(pages.keys()),
+module_query = st.query_params["module"] if "module" in st.query_params else None
+state_module = st.sidebar.radio(
+    "All Chains",
+    tuple(modules.keys()),
     index=(
-        tuple(pages.keys()).index(page_query)
-        if page_query and page_query in pages.keys()
+        tuple(modules.keys()).index(module_query)
+        if module_query and module_query in modules.keys()
         else 0
     ),
 )
-pages[state_page]()
+modules[state_module]()

--- a/dashboards/all_metrics/views/optimism.py
+++ b/dashboards/all_metrics/views/optimism.py
@@ -8,21 +8,21 @@ from dashboards.all_metrics.modules.v2 import (
 
 st.session_state.chain = "optimism_mainnet"
 
-pages = {
+modules = {
     "Perps V2": perp_stats.main,
     "Perps V2 Monitor": perp_monitor.main,
     "Perps V2 Markets": perp_markets.main,
     "Perps V2 Integrators": perp_integrators.main,
 }
 
-page_query = st.query_params["page"] if "page" in st.query_params else None
-state_page = st.sidebar.radio(
-    "Optimism",
-    tuple(pages.keys()),
+module_query = st.query_params["module"] if "module" in st.query_params else None
+state_module = st.sidebar.radio(
+    "All Chains",
+    tuple(modules.keys()),
     index=(
-        tuple(pages.keys()).index(page_query)
-        if page_query and page_query in pages.keys()
+        tuple(modules.keys()).index(module_query)
+        if module_query and module_query in modules.keys()
         else 0
     ),
 )
-pages[state_page]()
+modules[state_module]()

--- a/dashboards/key_metrics/views/links.py
+++ b/dashboards/key_metrics/views/links.py
@@ -1,22 +1,24 @@
 import streamlit as st
 from dashboards.utils.display import display_cards
 
+BASE_URL = "https://stats.synthetix.io"
+
 # card configs
 perps_cards = [
     {
         "title": "Base Perps",
         "text": "Synthetix V3 Perps on Base",
-        "url": "https://synthetix-all.streamlit.app/base?page=Perps",
+        "url": f"{BASE_URL}/all?page=base&module=Perps",
     },
     {
         "title": "Arbitrum Perps",
         "text": "Synthetix V3 Perps on Arbitrum",
-        "url": "https://synthetix-all.streamlit.app/arbitrum?page=Perps",
+        "url": f"{BASE_URL}/all?page=arbitrum&module=Perps",
     },
     {
         "title": "V2 Perps",
         "text": "Synthetix V2 Perps on Optimism",
-        "url": "https://synthetix-all.streamlit.app/optimism?page=Perps%20V2",
+        "url": f"{BASE_URL}/all?page=optimism&module=Perps%20V2",
     },
 ]
 
@@ -24,17 +26,17 @@ lp_cards = [
     {
         "title": "Base LP",
         "text": "Synthetix V3 liquidity pools on Base",
-        "url": "https://synthetix-all.streamlit.app/base?page=LP",
+        "url": f"{BASE_URL}/all?page=base&module=LP",
     },
     {
         "title": "Arbitrum LP",
         "text": "Synthetix V3 liquidity pools on Arbitrum",
-        "url": "https://synthetix-all.streamlit.app/arbitrum?page=LP",
+        "url": f"{BASE_URL}/all?page=arbitrum&module=LP",
     },
     {
         "title": "Ethereum LP",
         "text": "Synthetix V3 liquidity pools on Ethereum",
-        "url": "https://synthetix-all.streamlit.app/ethereum?page=LP",
+        "url": f"{BASE_URL}/all?page=ethereum&module=LP",
     },
 ]
 

--- a/dashboards/system_monitor/app.py
+++ b/dashboards/system_monitor/app.py
@@ -1,4 +1,3 @@
-import os
 from dotenv import load_dotenv
 import streamlit as st
 from api.internal_api import SynthetixAPI, get_db_config
@@ -11,7 +10,7 @@ if "network_id" not in st.session_state:
 
 st.set_page_config(
     page_title="Synthetix System Monitor",
-    page_icon=f"dashboards/static/favicon.ico",
+    page_icon="dashboards/static/favicon.ico",
     layout="wide",
 )
 


### PR DESCRIPTION
Update all links to use a `page` and `module` structure on the "All metrics" dashboard. This will improve direct linking, and enable all links to go through `stats.synthetix.io`

Links can be prepared like:
- [All metrics: Base perps](https://stats.synthetix.io/all?page=base&module=Perps)
- [All metrics - Arbitrum LP](https://stats.synthetix.io/all?page=arbitrum&module=LP)