### PR TITLE
Remove unknown token display

### DIFF
--- a/dashboards/all_metrics/modules/v3/all_core.py
+++ b/dashboards/all_metrics/modules/v3/all_core.py
@@ -29,6 +29,7 @@ def fetch_data(start_date, end_date, resolution):
         FROM {api.environment}_arbitrum_mainnet.fct_core_apr_arbitrum_mainnet apr
         LEFT JOIN {api.environment}_seeds.arbitrum_mainnet_tokens tk on lower(apr.collateral_type) = lower(tk.token_address)
         WHERE ts >= '{start_date}' and ts <= '{end_date}'
+            and tk.token_symbol is not null
         
         UNION ALL
         

--- a/dashboards/all_metrics/modules/v3/chain_core_stats.py
+++ b/dashboards/all_metrics/modules/v3/chain_core_stats.py
@@ -58,6 +58,7 @@ def fetch_data(chain, start_date, end_date, resolution):
             ON LOWER(apr.collateral_type) = LOWER(tk.token_address)
         WHERE ts >= '{start_date}' AND ts <= '{end_date}'
             AND pool_id = 1
+            and tk.token_symbol is not null
         ORDER BY ts
         """
     )

--- a/dashboards/key_metrics/views/cross_chain.py
+++ b/dashboards/key_metrics/views/cross_chain.py
@@ -139,7 +139,9 @@ if st.session_state.chain in [*SUPPORTED_CHAINS_CORE, "all"]:
         ),
     )
     chart_core_tvl_by_collateral = chart_area(
-        data["core_stats_by_collateral"],
+        data["core_stats_by_collateral"][
+            ~data["core_stats_by_collateral"]["label"].str.startswith("0x")
+        ],
         x_col="ts",
         y_cols="collateral_value",
         title="TVL by Collateral",
@@ -147,7 +149,9 @@ if st.session_state.chain in [*SUPPORTED_CHAINS_CORE, "all"]:
         custom_agg=dict(field="collateral_value", name="Total", agg="sum"),
     )
     chart_core_apr_by_collateral = chart_lines(
-        data["core_stats_by_collateral"],
+        data["core_stats_by_collateral"][
+            ~data["core_stats_by_collateral"]["label"].str.startswith("0x")
+        ],
         x_col="ts",
         y_cols=f"apr_{APR_RESOLUTION}",
         title="APR by Collateral (28d average)",

--- a/dashboards/key_metrics/views/lp.py
+++ b/dashboards/key_metrics/views/lp.py
@@ -84,7 +84,9 @@ with filter_col2:
     )
 
 chart_core_tvl_by_collateral = chart_area(
-    data["core_stats_by_collateral"],
+    data["core_stats_by_collateral"][
+        ~data["core_stats_by_collateral"].label.str.contains("0x")
+    ],
     x_col="ts",
     y_cols="collateral_value",
     title="TVL",
@@ -93,7 +95,9 @@ chart_core_tvl_by_collateral = chart_area(
     custom_agg=dict(field="collateral_value", name="Total", agg="sum"),
 )
 chart_core_apr_by_collateral = chart_lines(
-    data["core_stats_by_collateral"],
+    data["core_stats_by_collateral"][
+        ~data["core_stats_by_collateral"].label.str.contains("0x")
+    ],
     x_col="ts",
     y_cols=f"apr_{APR_RESOLUTION}",
     title=f"Total APR ({APR_RESOLUTION} average)",
@@ -103,7 +107,9 @@ chart_core_apr_by_collateral = chart_lines(
     help_text="APR includes pool performance and yields from underlying Aave deposits over the specified timeframe.",
 )
 chart_core_apr_rewards_by_collateral = chart_lines(
-    data["core_stats_by_collateral"],
+    data["core_stats_by_collateral"][
+        ~data["core_stats_by_collateral"].label.str.contains("0x")
+    ],
     x_col="ts",
     y_cols=f"apr_{APR_RESOLUTION}_rewards",
     title=f"Rewards APR ({APR_RESOLUTION} average)",


### PR DESCRIPTION
This corrects an issue where the deprecated sUSDe LP on Arbitrum displays erroneous data.

- Filter tokens that display by address instead of token symbol
